### PR TITLE
Rename system_prompt.j2 to system_prompt_interactive.j2 and restore original

### DIFF
--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -32,6 +32,7 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </VERSION_CONTROL>
 
 <PULL_REQUESTS>
+* **Important**: Do not push to the remote branch and/or start a pull request unless explicitly asked to do so.
 * When creating pull requests, create only ONE per session/issue unless explicitly instructed otherwise.
 * When working with an existing PR, update it with new commits rather than creating additional PRs for the same issue.
 * When updating a PR, preserve the original PR title and purpose, updating description only when necessary.

--- a/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
+++ b/openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2
@@ -32,7 +32,6 @@ Your primary role is to assist users by executing commands, modifying code, and 
 </VERSION_CONTROL>
 
 <PULL_REQUESTS>
-* **Important**: Do not push to the remote branch and/or start a pull request unless explicitly asked to do so.
 * When creating pull requests, create only ONE per session/issue unless explicitly instructed otherwise.
 * When working with an existing PR, update it with new commits rather than creating additional PRs for the same issue.
 * When updating a PR, preserve the original PR title and purpose, updating description only when necessary.
@@ -72,3 +71,16 @@ Your primary role is to assist users by executing commands, modifying code, and 
   4. Document your reasoning process
 * When you run into any major issue while executing a plan from the user, please don't try to directly work around it. Instead, propose a new plan and confirm with the user before proceeding.
 </TROUBLESHOOTING>
+
+<INTERACTION_RULES>
+* When the user instructions are high-level or vague, explore the codebase before implementing solutions or interacting with users to figure out the best approach.
+  1. Read and follow project-specific documentation (rules.md, README, etc.) before making assumptions about workflows, conventions, or feature implementations.
+  2. Deliver complete, production-ready solutions rather than partial implementations; ensure all components work together before presenting results.
+  3. Check for existing solutions and test cases before creating new implementations; leverage established patterns rather than reinventing functionality.
+
+* If you are not sure about the user's intent, ask for clarification before proceeding.
+  1. Always validate file existence and permissions before performing operations, and get back to users with clear error messages with specific paths when files are not found.
+  2. Support multilingual communication preferences and clarify requirements upfront to avoid repeated back-and-forth questioning.
+  3. Explain technical decisions clearly when making architectural choices, especially when creating new files or adding complexity to existing solutions.
+  4. Avoid resource waste by confirming requirements and approach before executing complex operations or generating extensive code.
+</INTERACTION_RULES>


### PR DESCRIPTION
This PR implements the requested changes to separate interactive and standard system prompts, starting from XuhuiZhou's existing `feat/interactional_system_prompt` branch.

## Changes Made

- **Created system_prompt_interactive.j2** - Contains the interactive modifications from XuhuiZhou's branch (including the `INTERACTION_RULES` section and removed push restriction)
- **Restored system_prompt.j2** - Now matches the main branch (without the interactive modifications)

## Purpose

This change allows for:
- Separate interactive and standard system prompts
- Preserving XuhuiZhou's interactive enhancements in the `_interactive` variant
- Maintaining backward compatibility with the standard system prompt
- Enabling different prompt behaviors for different use cases

## Files Changed

- `openhands/agenthub/codeact_agent/prompts/system_prompt_interactive.j2` (new file - contains XuhuiZhou's interactive modifications)
- `openhands/agenthub/codeact_agent/prompts/system_prompt.j2` (restored to match main branch)

## Diff Summary

This PR has a much smaller diff (only 2 files changed) compared to the previous attempt because it's based on XuhuiZhou's existing branch rather than starting from main.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b6d1014565554048ba6f0e0980321466)